### PR TITLE
Add local pipeline test and sample image generator

### DIFF
--- a/PNG
+++ b/PNG
@@ -313,7 +313,8 @@ def create_a4_canvas(svg_in: Path, svg_a4_out: Path):
     style_block = (
         "<style>path,rect,circle,ellipse,polygon,polyline,line{fill:#000000;stroke:none}</style>"
     )
-    template = f"""<?xml version="1.0" encoding="UTF-8"?>
+    template = (
+        f"""<?xml version="1.0" encoding="UTF-8"?>
 <svg width="{a4_w_px}px" height="{a4_h_px}px"
      viewBox="0 0 {a4_w_px} {a4_h_px}"
      xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -322,6 +323,7 @@ def create_a4_canvas(svg_in: Path, svg_a4_out: Path):
     {{content}}
   </g>
 </svg>"""
+    )
     full_raw_svg_content = Path(svg_in).read_text(encoding="utf-8")
     match = re.search(r"<svg[^>]*?>(.*?)</svg>", full_raw_svg_content, re.DOTALL)
     if match:
@@ -331,7 +333,7 @@ def create_a4_canvas(svg_in: Path, svg_a4_out: Path):
         inner_svg_content = full_raw_svg_content
     inner_svg_content = _ensure_black_fill_and_stroke(inner_svg_content)
     with open(svg_a4_out, "w", encoding="utf-8") as fh:
-        fh.write(template.format(content=inner_svg_content))
+        fh.write(template.replace("{content}", inner_svg_content))
     log.info("A4-Canvas erstellt: %s", svg_a4_out.name)
 
 def create_thumbnail(svg_path: Path, thumb_out: Path):
@@ -540,5 +542,23 @@ def main():
                 log.error("Unerwarteter Fehler für %s: %s", png_name, e)
     log.info("VERARBEITUNG ABGESCHLOSSEN – Statistik: %s", stats)
 
+
+def local_test(png_path: Path) -> None:
+    """Run the conversion pipeline locally without Firebase/Gemini."""
+    log.info("Lokaler Testlauf für %s", png_path.name)
+    svg_raw = Path("local_raw.svg")
+    svg_a4 = Path("local_a4.svg")
+    thumb = Path("local_thumb.png")
+    trace_png_to_svg(png_path, svg_raw)
+    create_a4_canvas(svg_raw, svg_a4)
+    create_thumbnail(svg_a4, thumb)
+    log.info("SVG valide: %s", _validate_svg(svg_a4))
+    log.info("Thumbnail valide: %s", _validate_thumbnail(thumb))
+
+
 if __name__ == "__main__":
-    main()
+    import sys
+    if len(sys.argv) > 1:
+        local_test(Path(sys.argv[1]))
+    else:
+        main()

--- a/generate_test_image.py
+++ b/generate_test_image.py
@@ -1,0 +1,11 @@
+from PIL import Image, ImageDraw
+img = Image.new('RGB', (300, 200), 'white')
+draw = ImageDraw.Draw(img)
+# car body
+draw.rectangle([50, 100, 250, 150], outline='black', width=5)
+# roof
+draw.polygon([(80,100),(120,70),(180,70),(220,100)], outline='black', width=5)
+# wheels
+draw.ellipse([70,150,110,190], outline='black', width=5)
+draw.ellipse([190,150,230,190], outline='black', width=5)
+img.save('test_car.png')


### PR DESCRIPTION
## Summary
- allow running the PNG pipeline locally by adding `local_test` mode
- fix `create_a4_canvas` template handling
- add small script to generate a sample line drawing

## Testing
- `python3 PNG test_car.png`

------
https://chatgpt.com/codex/tasks/task_e_685bdc960728832cb15db8a349c24958